### PR TITLE
Add postgres-mcp-server to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ for `EXPLAIN`, that also provides performance tips (Commercial Software).
 * [PostGraphile](https://github.com/graphile/postgraphile) - Instant GraphQL API or GraphQL schema for your PostgreSQL database
 * [yoke](https://github.com/nanopack/yoke) - PostgreSQL high-availability cluster with auto-failover and automated cluster recovery.
 * [pglistend](https://github.com/kabirbaidhya/pglistend) - A lightweight PostgresSQL `LISTEN`/`NOTIFY` daemon built on top of `node-postgres`.
+* [postgres-mcp-server](https://github.com/mgorunuch/postgres-mcp-server) - A Model Context Protocol (MCP) server that allows Claude and other AI assistants to interact with PostgreSQL databases.
 * [ZSON](https://github.com/postgrespro/zson) - PostgreSQL extension for transparent JSONB compression
 * [pg_bulkload](http://ossc-db.github.io/pg_bulkload/index.html) - It's a high speed data loading utility for PostgreSQL.
 * [pg_migrate](https://github.com/jwdeitch/pg_migrate) - Manage PostgreSQL codebases and make VCS simple.


### PR DESCRIPTION
This PR adds the postgres-mcp-server to the Utilities section.

The postgres-mcp-server is a Model Context Protocol (MCP) server that allows Claude and other AI assistants to interact with PostgreSQL databases, providing a secure and configurable interface for AI to execute database queries.